### PR TITLE
feat(properties/dcl): be able to clear LANDs' operators inside an estate

### DIFF
--- a/contracts/facets/decentraland/DecentralandFacet.sol
+++ b/contracts/facets/decentraland/DecentralandFacet.sol
@@ -140,6 +140,36 @@ contract DecentralandFacet is IDecentralandFacet {
         emit UpdateAdministrativeOperator(_administrativeOperator);
     }
 
+    /// @notice Clears the operators of Decentraland LANDs, which are part of a Decentraland Estate.
+    /// @dev LANDs' operators, which are part of an Estate, are not cleared upon Estate transfer.
+    /// The function's goal is to have the possibility to clear the operators of LANDs, which have been set
+    /// before the estate has been listed in LandWorks, otherwise whenever someone rents the estate, there might
+    /// be other operators, who can override the renter's scene.
+    /// @param _assetIds - The list of LandWorks asset ids.
+    /// @param _landIds - The list of landIds for each asset.
+    function clearEstateLANDOperators(
+        uint256[] memory _assetIds,
+        uint256[][] memory _landIds
+    ) external {
+        require(
+            _assetIds.length == _landIds.length,
+            "_assetIds and _landIds length must match"
+        );
+        LibMarketplace.MarketplaceStorage storage ms = LibMarketplace
+            .marketplaceStorage();
+
+        for (uint256 i = 0; i < _landIds.length; i++) {
+            LibMarketplace.Asset memory asset = ms.assets[_assetIds[i]];
+
+            IDecentralandRegistry(asset.metaverseRegistry)
+                .setManyLandUpdateOperator(
+                    asset.metaverseAssetId,
+                    _landIds[i],
+                    address(0)
+                );
+        }
+    }
+
     /// @notice Gets the administrative operator
     function administrativeOperator() external view returns (address) {
         return LibDecentraland.administrativeOperator();

--- a/contracts/interfaces/decentraland/IDecentralandFacet.sol
+++ b/contracts/interfaces/decentraland/IDecentralandFacet.sol
@@ -69,6 +69,8 @@ interface IDecentralandFacet is IRentable {
     /// The function's goal is to have the possibility to clear the operators of LANDs, which have been set
     /// before the estate has been listed in LandWorks, otherwise whenever someone rents the estate, there might
     /// be other operators, who can override the renter's scene.
+    /// @param _assetIds - The list of LandWorks asset ids.
+    /// @param _landIds - The list of landIds for each asset.
     function clearEstateLANDOperators(
         uint256[] memory _assetIds,
         uint256[][] memory _landIds

--- a/contracts/interfaces/decentraland/IDecentralandFacet.sol
+++ b/contracts/interfaces/decentraland/IDecentralandFacet.sol
@@ -64,6 +64,16 @@ interface IDecentralandFacet is IRentable {
     function updateAdministrativeOperator(address _administrativeOperator)
         external;
 
+    /// @notice Clears the operators of Decentraland LANDs, which are part of a Decentraland Estate.
+    /// @dev LANDs' operators, which are part of an Estate, are not cleared upon Estate transfer.
+    /// The function's goal is to have the possibility to clear the operators of LANDs, which have been set
+    /// before the estate has been listed in LandWorks, otherwise whenever someone rents the estate, there might
+    /// be other operators, who can override the renter's scene.
+    function clearEstateLANDOperators(
+        uint256[] memory _assetIds,
+        uint256[][] memory _landIds
+    ) external;
+
     /// @notice Gets the administrative operator
     function administrativeOperator() external view returns (address);
 

--- a/contracts/interfaces/decentraland/IDecentralandRegistry.sol
+++ b/contracts/interfaces/decentraland/IDecentralandRegistry.sol
@@ -6,4 +6,15 @@ interface IDecentralandRegistry {
     /// @param _assetId - Estate/LAND id
     /// @param _operator - the to-be-set as operator
     function setUpdateOperator(uint256 _assetId, address _operator) external;
+
+    /// @notice Sets LANDs operator inside of an Estate.
+    /// @dev LANDs' operators, which are part of an Estate, are not cleared upon estate transfer.
+    /// @param _estateId - The target Estate id.
+    /// @param _landIds - An array of LANDs, which are part of the estate.
+    /// @param _operator - The operator to-be-set to the lands.
+    function setManyLandUpdateOperator(
+        uint256 _estateId,
+        uint256[] memory _landIds,
+        address _operator
+    ) external;
 }


### PR DESCRIPTION
**Detailed description**:
* Be able to set LANDs' operators inside an estate to `0x0`, so that past operators of the LANDs are not left during a rent.

**Which issue(s) this PR fixes**:
Fixes #none

**Special notes for your reviewer**:

**Checklist**
- [ ] Documentation added
- [x] Tests updated