### PR TITLE
feat(list): set administrative operator/consumer upon listing

### DIFF
--- a/contracts/facets/MetaverseConsumableAdapterFacet.sol
+++ b/contracts/facets/MetaverseConsumableAdapterFacet.sol
@@ -34,7 +34,7 @@ contract MetaverseConsumableAdapterFacet is IMetaverseConsumableAdapterFacet {
     /// @param _pricePerSecond The price for rental per second
     /// @param _referrer The target referrer
     /// @return The newly created asset id.
-    function listAndSetAdminConsumer(
+    function listWithConsumableAdapter(
         uint256 _metaverseId,
         address _metaverseRegistry,
         uint256 _metaverseAssetId,

--- a/contracts/facets/MetaverseConsumableAdapterFacet.sol
+++ b/contracts/facets/MetaverseConsumableAdapterFacet.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.10;
 import "../interfaces/IERC721Consumable.sol";
 import "../interfaces/IMetaverseConsumableAdapterFacet.sol";
 import "../libraries/LibOwnership.sol";
+import "../libraries/marketplace/LibList.sol";
 import "../libraries/marketplace/LibMetaverseConsumableAdapter.sol";
 import "../libraries/marketplace/LibMarketplace.sol";
 import "../libraries/marketplace/LibRent.sol";
@@ -12,6 +13,59 @@ import "../libraries/marketplace/LibRent.sol";
 /// with metaverses having an external consumable adapter, used
 /// to store consumers of LandWorks NFTs upon rentals.
 contract MetaverseConsumableAdapterFacet is IMetaverseConsumableAdapterFacet {
+    /// @notice Provides asset of the given metaverse registry for rental.
+    /// Transfers and locks the provided metaverse asset to the contract.
+    /// and mints an asset, representing the locked asset.
+    /// Listing with a referrer might lead to additional rewards upon rents.
+    /// Additional reward may vary depending on the referrer's requested portion for listers.
+    /// If the referrer is blacklisted after the listing,
+    /// listers will not receive additional rewards.
+    /// See {IReferralFacet-setMetaverseRegistryReferrers}, {IReferralFacet-setReferrers}.
+    /// Updates the corresponding Metaverse Consumer Adapter with the administrative operator.
+    /// @param _metaverseId The id of the metaverse
+    /// @param _metaverseRegistry The registry of the metaverse
+    /// @param _metaverseAssetId The id from the metaverse registry
+    /// @param _minPeriod The minimum number of time (in seconds) the asset can be rented
+    /// @param _maxPeriod The maximum number of time (in seconds) the asset can be rented
+    /// @param _maxFutureTime The timestamp delta after which the protocol will not allow
+    /// the asset to be rented at an any given moment.
+    /// @param _paymentToken The token which will be accepted as a form of payment.
+    /// Provide 0x0000000000000000000000000000000000000001 for ETH.
+    /// @param _pricePerSecond The price for rental per second
+    /// @param _referrer The target referrer
+    /// @return The newly created asset id.
+    function listAndSetAdminConsumer(
+        uint256 _metaverseId,
+        address _metaverseRegistry,
+        uint256 _metaverseAssetId,
+        uint256 _minPeriod,
+        uint256 _maxPeriod,
+        uint256 _maxFutureTime,
+        address _paymentToken,
+        uint256 _pricePerSecond,
+        address _referrer
+    ) external returns (uint256) {
+        uint256 assetId = LibList.list(
+            _metaverseId,
+            _metaverseRegistry,
+            _metaverseAssetId,
+            _minPeriod,
+            _maxPeriod,
+            _maxFutureTime,
+            _paymentToken,
+            _pricePerSecond,
+            _referrer
+        );
+
+        updateAdapterAdministrativeOperator(
+            assetId,
+            _metaverseRegistry,
+            _metaverseAssetId
+        );
+
+        return assetId;
+    }
+
     /// @notice Sets the metaverse consumable adapter
     /// @param _metaverseRegistry The target metaverse registry (token address)
     /// @param _consumableAdapter The address of the consumable adapter
@@ -179,16 +233,25 @@ contract MetaverseConsumableAdapterFacet is IMetaverseConsumableAdapterFacet {
             storage mcas = LibMetaverseConsumableAdapter
                 .metaverseConsumableAdapterStorage();
 
-        address consumer = mcas.administrativeConsumers[
-            asset.metaverseRegistry
-        ];
-
-        address adapter = mcas.consumableAdapters[asset.metaverseRegistry];
-
-        IERC721Consumable(adapter).changeConsumer(
-            consumer,
+        updateAdapterAdministrativeOperator(
+            _assetId,
+            asset.metaverseRegistry,
             asset.metaverseAssetId
         );
+    }
+
+    function updateAdapterAdministrativeOperator(
+        uint256 _assetId,
+        address _metaverseRegistry,
+        uint256 _metaverseAssetId
+    ) internal {
+        LibMetaverseConsumableAdapter.MetaverseConsumableAdapterStorage
+            storage mcas = LibMetaverseConsumableAdapter
+                .metaverseConsumableAdapterStorage();
+
+        address consumer = mcas.administrativeConsumers[_metaverseRegistry];
+        address adapter = mcas.consumableAdapters[_metaverseRegistry];
+        IERC721Consumable(adapter).changeConsumer(consumer, _metaverseAssetId);
 
         emit UpdateAdapterAdministrativeConsumer(_assetId, adapter, consumer);
     }

--- a/contracts/facets/decentraland/DecentralandFacet.sol
+++ b/contracts/facets/decentraland/DecentralandFacet.sol
@@ -6,8 +6,62 @@ import "../../interfaces/decentraland/IDecentralandRegistry.sol";
 import "../../libraries/LibOwnership.sol";
 import "../../libraries/marketplace/LibRent.sol";
 import "../../libraries/marketplace/LibDecentraland.sol";
+import "../../libraries/marketplace/LibList.sol";
 
 contract DecentralandFacet is IDecentralandFacet {
+    /// @notice Provides asset of the given metaverse registry for rental.
+    /// Transfers and locks the provided metaverse asset to the contract.
+    /// and mints an asset, representing the locked asset.
+    /// Listing with a referrer might lead to additional rewards upon rents.
+    /// Additional reward may vary depending on the referrer's requested portion for listers.
+    /// If the referrer is blacklisted after the listing,
+    /// listers will not receive additional rewards.
+    /// See {IReferralFacet-setMetaverseRegistryReferrers}, {IReferralFacet-setReferrers}.
+    /// Updates the corresponding Estate/LAND operator with the administrative operator.
+    /// @param _metaverseId The id of the metaverse
+    /// @param _metaverseRegistry The registry of the metaverse
+    /// @param _metaverseAssetId The id from the metaverse registry
+    /// @param _minPeriod The minimum number of time (in seconds) the asset can be rented
+    /// @param _maxPeriod The maximum number of time (in seconds) the asset can be rented
+    /// @param _maxFutureTime The timestamp delta after which the protocol will not allow
+    /// the asset to be rented at an any given moment.
+    /// @param _paymentToken The token which will be accepted as a form of payment.
+    /// Provide 0x0000000000000000000000000000000000000001 for ETH.
+    /// @param _pricePerSecond The price for rental per second
+    /// @param _referrer The target referrer
+    /// @return The newly created asset id.
+    function listDecentraland(
+        uint256 _metaverseId,
+        address _metaverseRegistry,
+        uint256 _metaverseAssetId,
+        uint256 _minPeriod,
+        uint256 _maxPeriod,
+        uint256 _maxFutureTime,
+        address _paymentToken,
+        uint256 _pricePerSecond,
+        address _referrer
+    ) external returns (uint256) {
+        uint256 assetId = LibList.list(
+            _metaverseId,
+            _metaverseRegistry,
+            _metaverseAssetId,
+            _minPeriod,
+            _maxPeriod,
+            _maxFutureTime,
+            _paymentToken,
+            _pricePerSecond,
+            _referrer
+        );
+
+        updateAdministrativeOperator(
+            assetId,
+            _metaverseRegistry,
+            _metaverseAssetId
+        );
+
+        return assetId;
+    }
+
     /// @notice Rents Decentraland Estate/LAND.
     /// @param _assetId The target asset
     /// @param _period The target period of the rental
@@ -91,14 +145,11 @@ contract DecentralandFacet is IDecentralandFacet {
             "_assetId has an active rent"
         );
 
-        address operator = LibDecentraland
-            .decentralandStorage()
-            .administrativeOperator;
-        IDecentralandRegistry(asset.metaverseRegistry).setUpdateOperator(
-            asset.metaverseAssetId,
-            operator
+        updateAdministrativeOperator(
+            _assetId,
+            asset.metaverseRegistry,
+            asset.metaverseAssetId
         );
-        emit UpdateAdministrativeState(_assetId, operator);
     }
 
     /// @notice Updates the operator for the given rent of an asset
@@ -138,6 +189,21 @@ contract DecentralandFacet is IDecentralandFacet {
         LibDecentraland.setAdministrativeOperator(_administrativeOperator);
 
         emit UpdateAdministrativeOperator(_administrativeOperator);
+    }
+
+    function updateAdministrativeOperator(
+        uint256 _assetId,
+        address _metaverseRegistry,
+        uint256 _metaverseAssetId
+    ) internal {
+        address operator = LibDecentraland
+            .decentralandStorage()
+            .administrativeOperator;
+        IDecentralandRegistry(_metaverseRegistry).setUpdateOperator(
+            _metaverseAssetId,
+            operator
+        );
+        emit UpdateAdministrativeState(_assetId, operator);
     }
 
     /// @notice Gets the administrative operator

--- a/contracts/facets/decentraland/DecentralandFacet.sol
+++ b/contracts/facets/decentraland/DecentralandFacet.sol
@@ -4,9 +4,9 @@ pragma solidity 0.8.10;
 import "../../interfaces/decentraland/IDecentralandFacet.sol";
 import "../../interfaces/decentraland/IDecentralandRegistry.sol";
 import "../../libraries/LibOwnership.sol";
-import "../../libraries/marketplace/LibRent.sol";
 import "../../libraries/marketplace/LibDecentraland.sol";
 import "../../libraries/marketplace/LibList.sol";
+import "../../libraries/marketplace/LibRent.sol";
 
 contract DecentralandFacet is IDecentralandFacet {
     /// @notice Provides asset of the given metaverse registry for rental.

--- a/contracts/interfaces/IMetaverseConsumableAdapterFacet.sol
+++ b/contracts/interfaces/IMetaverseConsumableAdapterFacet.sol
@@ -31,6 +31,39 @@ interface IMetaverseConsumableAdapterFacet {
         address indexed _consumer
     );
 
+    /// @notice Provides asset of the given metaverse registry for rental.
+    /// Transfers and locks the provided metaverse asset to the contract.
+    /// and mints an asset, representing the locked asset.
+    /// Listing with a referrer might lead to additional rewards upon rents.
+    /// Additional reward may vary depending on the referrer's requested portion for listers.
+    /// If the referrer is blacklisted after the listing,
+    /// listers will not receive additional rewards.
+    /// See {IReferralFacet-setMetaverseRegistryReferrers}, {IReferralFacet-setReferrers}.
+    /// Updates the corresponding Metaverse Consumer Adapter with the administrative operator.
+    /// @param _metaverseId The id of the metaverse
+    /// @param _metaverseRegistry The registry of the metaverse
+    /// @param _metaverseAssetId The id from the metaverse registry
+    /// @param _minPeriod The minimum number of time (in seconds) the asset can be rented
+    /// @param _maxPeriod The maximum number of time (in seconds) the asset can be rented
+    /// @param _maxFutureTime The timestamp delta after which the protocol will not allow
+    /// the asset to be rented at an any given moment.
+    /// @param _paymentToken The token which will be accepted as a form of payment.
+    /// Provide 0x0000000000000000000000000000000000000001 for ETH.
+    /// @param _pricePerSecond The price for rental per second
+    /// @param _referrer The target referrer
+    /// @return The newly created asset id.
+    function listAndSetAdminConsumer(
+        uint256 _metaverseId,
+        address _metaverseRegistry,
+        uint256 _metaverseAssetId,
+        uint256 _minPeriod,
+        uint256 _maxPeriod,
+        uint256 _maxFutureTime,
+        address _paymentToken,
+        uint256 _pricePerSecond,
+        address _referrer
+    ) external returns (uint256);
+
     /// @notice Sets the metaverse consumable adapter
     /// @param _metaverseRegistry The target metaverse registry (token address)
     /// @param _consumableAdapter The address of the consumable adapter

--- a/contracts/interfaces/IMetaverseConsumableAdapterFacet.sol
+++ b/contracts/interfaces/IMetaverseConsumableAdapterFacet.sol
@@ -52,7 +52,7 @@ interface IMetaverseConsumableAdapterFacet {
     /// @param _pricePerSecond The price for rental per second
     /// @param _referrer The target referrer
     /// @return The newly created asset id.
-    function listAndSetAdminConsumer(
+    function listWithConsumableAdapter(
         uint256 _metaverseId,
         address _metaverseRegistry,
         uint256 _metaverseAssetId,

--- a/contracts/interfaces/decentraland/IDecentralandFacet.sol
+++ b/contracts/interfaces/decentraland/IDecentralandFacet.sol
@@ -20,6 +20,39 @@ interface IDecentralandFacet is IRentable {
     );
     event UpdateAdministrativeOperator(address _administrativeOperator);
 
+    /// @notice Provides asset of the given metaverse registry for rental.
+    /// Transfers and locks the provided metaverse asset to the contract.
+    /// and mints an asset, representing the locked asset.
+    /// Listing with a referrer might lead to additional rewards upon rents.
+    /// Additional reward may vary depending on the referrer's requested portion for listers.
+    /// If the referrer is blacklisted after the listing,
+    /// listers will not receive additional rewards.
+    /// See {IReferralFacet-setMetaverseRegistryReferrers}, {IReferralFacet-setReferrers}.
+    /// Updates the corresponding Estate/LAND operator with the administrative operator.
+    /// @param _metaverseId The id of the metaverse
+    /// @param _metaverseRegistry The registry of the metaverse
+    /// @param _metaverseAssetId The id from the metaverse registry
+    /// @param _minPeriod The minimum number of time (in seconds) the asset can be rented
+    /// @param _maxPeriod The maximum number of time (in seconds) the asset can be rented
+    /// @param _maxFutureTime The timestamp delta after which the protocol will not allow
+    /// the asset to be rented at an any given moment.
+    /// @param _paymentToken The token which will be accepted as a form of payment.
+    /// Provide 0x0000000000000000000000000000000000000001 for ETH.
+    /// @param _pricePerSecond The price for rental per second
+    /// @param _referrer The target referrer
+    /// @return The newly created asset id.
+    function listDecentraland(
+        uint256 _metaverseId,
+        address _metaverseRegistry,
+        uint256 _metaverseAssetId,
+        uint256 _minPeriod,
+        uint256 _maxPeriod,
+        uint256 _maxFutureTime,
+        address _paymentToken,
+        uint256 _pricePerSecond,
+        address _referrer
+    ) external returns (uint256);
+
     /// @notice Rents Decentraland Estate/LAND.
     /// @param _assetId The target asset
     /// @param _period The target period of the rental

--- a/contracts/libraries/marketplace/LibList.sol
+++ b/contracts/libraries/marketplace/LibList.sol
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.10;
+
+import "../LibERC721.sol";
+import "../LibFee.sol";
+import "../LibReferral.sol";
+import "../LibTransfer.sol";
+import "../marketplace/LibMarketplace.sol";
+
+library LibList {
+    event List(
+        uint256 _assetId,
+        uint256 _metaverseId,
+        address indexed _metaverseRegistry,
+        uint256 indexed _metaverseAssetId,
+        uint256 _minPeriod,
+        uint256 _maxPeriod,
+        uint256 _maxFutureTime,
+        address indexed _paymentToken,
+        uint256 _pricePerSecond
+    );
+
+    /// @notice Provides asset of the given metaverse registry for rental.
+    /// Transfers and locks the provided metaverse asset to the contract.
+    /// and mints an asset, representing the locked asset.
+    /// Listing with a referrer might lead to additional rewards upon rents.
+    /// Additional reward may vary depending on the referrer's requested portion for listers.
+    /// If the referrer is blacklisted after the listing,
+    /// listers will not receive additional rewards.
+    /// See {IReferralFacet-setMetaverseRegistryReferrers}, {IReferralFacet-setReferrers}.
+    /// @param _metaverseId The id of the metaverse
+    /// @param _metaverseRegistry The registry of the metaverse
+    /// @param _metaverseAssetId The id from the metaverse registry
+    /// @param _minPeriod The minimum number of time (in seconds) the asset can be rented
+    /// @param _maxPeriod The maximum number of time (in seconds) the asset can be rented
+    /// @param _maxFutureTime The timestamp delta after which the protocol will not allow
+    /// the asset to be rented at an any given moment.
+    /// @param _paymentToken The token which will be accepted as a form of payment.
+    /// Provide 0x0000000000000000000000000000000000000001 for ETH.
+    /// @param _pricePerSecond The price for rental per second
+    /// @param _referrer The target referrer
+    /// @return The newly created asset id.
+    function list(
+        uint256 _metaverseId,
+        address _metaverseRegistry,
+        uint256 _metaverseAssetId,
+        uint256 _minPeriod,
+        uint256 _maxPeriod,
+        uint256 _maxFutureTime,
+        address _paymentToken,
+        uint256 _pricePerSecond,
+        address _referrer
+    ) internal returns (uint256) {
+        require(
+            _metaverseRegistry != address(0),
+            "_metaverseRegistry must not be 0x0"
+        );
+        require(
+            LibMarketplace.supportsRegistry(_metaverseId, _metaverseRegistry),
+            "_registry not supported"
+        );
+        require(_minPeriod != 0, "_minPeriod must not be 0");
+        require(_maxPeriod != 0, "_maxPeriod must not be 0");
+        require(_minPeriod <= _maxPeriod, "_minPeriod more than _maxPeriod");
+        require(
+            _maxPeriod <= _maxFutureTime,
+            "_maxPeriod more than _maxFutureTime"
+        );
+        require(
+            LibFee.supportsTokenPayment(_paymentToken),
+            "payment type not supported"
+        );
+        if (_referrer != address(0)) {
+            LibReferral.ReferrerPercentage memory rp = LibReferral
+                .referralStorage()
+                .referrerPercentages[_referrer];
+            require(rp.mainPercentage > 0, "_referrer not whitelisted");
+        }
+
+        uint256 asset = LibERC721.safeMint(msg.sender);
+        {
+            LibMarketplace.MarketplaceStorage storage ms = LibMarketplace
+                .marketplaceStorage();
+            ms.assets[asset] = LibMarketplace.Asset({
+                metaverseId: _metaverseId,
+                metaverseRegistry: _metaverseRegistry,
+                metaverseAssetId: _metaverseAssetId,
+                paymentToken: _paymentToken,
+                minPeriod: _minPeriod,
+                maxPeriod: _maxPeriod,
+                maxFutureTime: _maxFutureTime,
+                pricePerSecond: _pricePerSecond,
+                status: LibMarketplace.AssetStatus.Listed,
+                totalRents: 0
+            });
+            LibReferral.referralStorage().listReferrer[asset] = _referrer;
+
+            LibTransfer.erc721SafeTransferFrom(
+                _metaverseRegistry,
+                msg.sender,
+                address(this),
+                _metaverseAssetId
+            );
+        }
+        emit List(
+            asset,
+            _metaverseId,
+            _metaverseRegistry,
+            _metaverseAssetId,
+            _minPeriod,
+            _maxPeriod,
+            _maxFutureTime,
+            _paymentToken,
+            _pricePerSecond
+        );
+        return asset;
+    }
+}

--- a/test/diamond.test.ts
+++ b/test/diamond.test.ts
@@ -2644,19 +2644,26 @@ describe('LandWorks', function () {
         const expectedRentFee = value - expectedProtocolFee;
         const rentId = 1;
 
+        let metaverseTokenId: any;
+        let mockERC20Registry: Contract;
+
         beforeEach(async () => {
             // given:
             await landWorks.setRegistry(metaverseId, landRegistry.address, true);
             await landWorks.setFee(ADDRESS_ONE, FEE_PERCENTAGE);
 
             // Mint LAND
-            const x = 0, y = 0;
-            await landRegistry.authorizeDeploy(owner.address);
-            await landRegistry.assignNewParcel(x, y, owner.address);
-            const landId = await landRegistry.encodeTokenId(x, y);
-            // and:
-            await landRegistry.approve(landWorks.address, landId);
+            const x = [0, 42], y = [0, 42];
 
+            await landRegistry.authorizeDeploy(owner.address);
+            await landRegistry.assignMultipleParcels(x, y, owner.address);
+            const landId = await landRegistry.encodeTokenId(x[0], y[0]);
+            metaverseTokenId = await landRegistry.encodeTokenId(x[1], y[1]);
+
+            // and:
+            await landRegistry.setApprovalForAll(landWorks.address, true);
+
+            // and:
             await landWorks
                 .list(
                     metaverseId,
@@ -2669,6 +2676,344 @@ describe('LandWorks', function () {
                     pricePerSecond,
                     ethers.constants.AddressZero
                 );
+
+            // and:
+            mockERC20Registry = await Deployer.deployContract('ERC20Mock');
+        });
+
+        describe('listDecentraland', async () => {
+            const assetId = 1;
+
+            it('should list successfully', async () => {
+                // given:
+                await landRegistry.approve(landWorks.address, metaverseTokenId);
+
+                // when:
+                await landWorks.listDecentraland(metaverseId, landRegistry.address, metaverseTokenId, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+
+                // then:
+                expect(await landRegistry.ownerOf(metaverseTokenId)).to.equal(landWorks.address);
+                expect(await landWorks.ownerOf(assetId)).to.equal(owner.address);
+                // and:
+                const asset = await landWorks.assetAt(assetId);
+                expect(asset.metaverseId).to.equal(metaverseId);
+                expect(asset.metaverseRegistry).to.equal(landRegistry.address);
+                expect(asset.metaverseAssetId).to.equal(metaverseTokenId);
+                expect(asset.paymentToken).to.equal(ADDRESS_ONE);
+                expect(asset.minPeriod).to.equal(minPeriod);
+                expect(asset.maxPeriod).to.equal(maxPeriod);
+                expect(asset.maxFutureTime).to.equal(maxFutureTime);
+                expect(asset.pricePerSecond).equal(pricePerSecond);
+                expect(asset.status).to.equal(0); // Listed
+                expect(asset.totalRents).to.equal(0);
+                expect(await landWorks.totalSupply()).to.equal(2);
+                expect(await landWorks.tokenOfOwnerByIndex(owner.address, assetId)).to.equal(assetId);
+                expect(await landWorks.tokenByIndex(assetId)).to.equal(assetId);
+            });
+
+            it('should emit event with args', async () => {
+                // given:
+                await landWorks.updateAdministrativeOperator(administrativeOperator.address);
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.emit(landWorks, 'ConsumerChanged')
+                    .withArgs(ethers.constants.AddressZero, ethers.constants.AddressZero, assetId)
+                    .to.emit(landWorks, 'Transfer')
+                    .withArgs(ethers.constants.AddressZero, owner.address, assetId)
+                    .to.emit(landWorks, 'List')
+                    .withArgs(assetId, metaverseId, landRegistry.address, metaverseTokenId, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond)
+                    .to.emit(landWorks, 'UpdateAdministrativeState')
+                    .withArgs(assetId, administrativeOperator.address)
+                    .to.emit(landRegistry, 'UpdateOperator')
+                    .withArgs(metaverseTokenId, administrativeOperator.address);
+            });
+
+            it('should list successfully with a payment token', async () => {
+                // and:
+                await landWorks.setTokenPayment(mockERC20Registry.address, 0, true);
+
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        mockERC20Registry.address,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.emit(landWorks, 'ConsumerChanged')
+                    .withArgs(ethers.constants.AddressZero, ethers.constants.AddressZero, assetId)
+                    .to.emit(landWorks, 'Transfer')
+                    .withArgs(ethers.constants.AddressZero, owner.address, assetId)
+                    .to.emit(landWorks, 'List')
+                    .withArgs(1, metaverseId, landRegistry.address, metaverseTokenId, minPeriod, maxPeriod, maxFutureTime, mockERC20Registry.address, pricePerSecond);
+
+                // then:
+                expect(await landRegistry.ownerOf(metaverseTokenId)).to.equal(landWorks.address);
+                expect(await landWorks.ownerOf(assetId)).to.equal(owner.address);
+                // and:
+                const asset = await landWorks.assetAt(assetId);
+                expect(asset.metaverseId).to.equal(metaverseId);
+                expect(asset.metaverseRegistry).to.equal(landRegistry.address);
+                expect(asset.metaverseAssetId).to.equal(metaverseTokenId);
+                expect(asset.paymentToken).to.equal(mockERC20Registry.address);
+                expect(asset.minPeriod).to.equal(minPeriod);
+                expect(asset.maxPeriod).to.equal(maxPeriod);
+                expect(asset.maxFutureTime).to.equal(maxFutureTime);
+                expect(asset.pricePerSecond).equal(pricePerSecond);
+                expect(asset.status).to.equal(0); // Listed
+                expect(asset.totalRents).to.equal(0);
+            });
+
+            it('should revert when metaverse registry is 0x0', async () => {
+                const expectedRevertMessage = '_metaverseRegistry must not be 0x0';
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        ethers.constants.AddressZero,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        mockERC20Registry.address,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.revertedWith(expectedRevertMessage);
+            });
+
+            it('should revert when min period is 0', async () => {
+                const expectedRevertMessage = '_minPeriod must not be 0';
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        0,
+                        maxPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.revertedWith(expectedRevertMessage);
+            });
+
+            it('should revert when max period is 0', async () => {
+                const expectedRevertMessage = '_maxPeriod must not be 0';
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        0,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.revertedWith(expectedRevertMessage);
+            });
+
+            it('should revert when min period exceeds max period', async () => {
+                const expectedRevertMessage = '_minPeriod more than _maxPeriod';
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        maxPeriod,
+                        minPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.revertedWith(expectedRevertMessage);
+            });
+
+            it('should revert when max period exceeds max future time', async () => {
+                const expectedRevertMessage = '_maxPeriod more than _maxFutureTime';
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxFutureTime,
+                        maxPeriod,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.revertedWith(expectedRevertMessage);
+            });
+
+            it('should revert when registry is not supported', async () => {
+                const expectedRevertMessage = '_registry not supported';
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        artificialRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.revertedWith(expectedRevertMessage);
+            });
+
+            it('should revert when payment token is not supported', async () => {
+                const expectedRevertMessage = 'payment type not supported';
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        mockERC20Registry.address,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.revertedWith(expectedRevertMessage);
+            });
+
+            it('should revert when trying to list a non-existing metaverse token id', async () => {
+                const invalidTokenId = 1234;
+                const expectedRevertMessage = 'ERC721: operator query for nonexistent token';
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        invalidTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.reverted;
+            });
+
+            it('should revert when trying to list to a non-contract metaverse registry', async () => {
+                // given:
+                await landWorks.setRegistry(metaverseId, artificialRegistry.address, true);
+
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        artificialRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.reverted;
+            });
+
+            it('should revert when caller is not owner of the to-be-listed asset', async () => {
+                // given:
+                await landRegistry.setApprovalForAll(landWorks.address, false);
+
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.reverted;
+            });
+
+            it('should revert when referrer is not whitelisted', async () => {
+                const expectedRevertMessage = '_referrer not whitelisted';
+
+                // when:
+                await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        nonOwner.address
+                    ))
+                    .to.be.revertedWith(expectedRevertMessage);
+            });
+
+            it('withdrawing and listing again should not get the old token id for the latest asset', async () => {
+                const newlyGeneratedTokenId = 2;
+                // given:
+                await landWorks.listDecentraland(metaverseId, landRegistry.address, metaverseTokenId, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+                await landWorks.delist(assetId);
+
+                // when:
+                await landWorks.listDecentraland(metaverseId, landRegistry.address, metaverseTokenId, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+
+                // then:
+                await expect(landWorks.ownerOf(assetId)).to.be.revertedWith('ERC721: owner query for nonexistent token');
+                // and:
+                expect(await landRegistry.ownerOf(metaverseTokenId)).to.equal(landWorks.address);
+                expect(await landWorks.ownerOf(newlyGeneratedTokenId)).to.be.equal(owner.address);
+                // and:
+                const asset = await landWorks.assetAt(newlyGeneratedTokenId);
+                expect(asset.metaverseId).to.equal(metaverseId);
+                expect(asset.metaverseRegistry).to.equal(landRegistry.address);
+                expect(asset.metaverseAssetId).to.equal(metaverseTokenId);
+                expect(asset.paymentToken).to.equal(ADDRESS_ONE);
+                expect(asset.minPeriod).to.equal(minPeriod);
+                expect(asset.maxPeriod).to.equal(maxPeriod);
+                expect(asset.maxFutureTime).to.equal(maxFutureTime);
+                expect(asset.pricePerSecond).equal(pricePerSecond);
+                expect(asset.status).to.equal(0); // Listed
+                expect(asset.totalRents).to.equal(0);
+                expect(await landWorks.totalSupply()).to.equal(2);
+                expect(await landWorks.tokenOfOwnerByIndex(owner.address, 1)).to.equal(newlyGeneratedTokenId);
+                expect(await landWorks.tokenByIndex(1)).to.equal(newlyGeneratedTokenId);
+            });
         });
 
         describe('rentDecentraland', async () => {

--- a/test/diamond.test.ts
+++ b/test/diamond.test.ts
@@ -2686,6 +2686,7 @@ describe('LandWorks', function () {
 
             it('should list successfully', async () => {
                 // given:
+                await landWorks.updateAdministrativeOperator(administrativeOperator.address);
                 await landRegistry.approve(landWorks.address, metaverseTokenId);
 
                 // when:
@@ -2709,6 +2710,8 @@ describe('LandWorks', function () {
                 expect(await landWorks.totalSupply()).to.equal(2);
                 expect(await landWorks.tokenOfOwnerByIndex(owner.address, assetId)).to.equal(assetId);
                 expect(await landWorks.tokenByIndex(assetId)).to.equal(assetId);
+                // and:
+                expect(await landRegistry.updateOperator(metaverseTokenId)).to.equal(administrativeOperator.address);
             });
 
             it('should emit event with args', async () => {
@@ -2740,8 +2743,9 @@ describe('LandWorks', function () {
             });
 
             it('should list successfully with a payment token', async () => {
-                // and:
+                // given:
                 await landWorks.setTokenPayment(mockERC20Registry.address, 0, true);
+                await landWorks.updateAdministrativeOperator(administrativeOperator.address);
 
                 // when:
                 await expect(landWorks
@@ -2778,6 +2782,8 @@ describe('LandWorks', function () {
                 expect(asset.pricePerSecond).equal(pricePerSecond);
                 expect(asset.status).to.equal(0); // Listed
                 expect(asset.totalRents).to.equal(0);
+                // and:
+                expect(await landRegistry.updateOperator(metaverseTokenId)).to.equal(administrativeOperator.address);
             });
 
             it('should revert when metaverse registry is 0x0', async () => {
@@ -2945,12 +2951,30 @@ describe('LandWorks', function () {
                     .to.be.reverted;
             });
 
-            it('should revert when caller is not owner of the to-be-listed asset', async () => {
+            it('should revert when caller is not approved of the to-be-listed asset', async () => {
                 // given:
                 await landRegistry.setApprovalForAll(landWorks.address, false);
 
                 // when:
                 await expect(landWorks
+                    .listDecentraland(
+                        metaverseId,
+                        landRegistry.address,
+                        metaverseTokenId,
+                        minPeriod,
+                        maxPeriod,
+                        maxFutureTime,
+                        ADDRESS_ONE,
+                        pricePerSecond,
+                        ethers.constants.AddressZero
+                    ))
+                    .to.be.reverted;
+            });
+
+            it('should revert when caller is not owner of the to-be-listed asset', async () => {
+                // when:
+                await expect(landWorks
+                    .connect(administrativeOperator)
                     .listDecentraland(
                         metaverseId,
                         landRegistry.address,
@@ -3805,6 +3829,7 @@ describe('LandWorks', function () {
         let mockERC721Registry: Contract;
         let metaverseAdapter: Contract;
         const tokenID = 1;
+        const secondMetaverseTokenID = 2;
         const metaverseID = 1;
         const metaverseName = 'NoConsumer';
         const minPeriod = 1;
@@ -3831,6 +3856,7 @@ describe('LandWorks', function () {
 
             mockERC721Registry = await Deployer.deployContract('ERC721Mock');
             await mockERC721Registry.mint(owner.address, tokenID);
+            await mockERC721Registry.mint(owner.address, secondMetaverseTokenID);
             metaverseAdapter = await Deployer.deployContract('ConsumableAdapterV1', undefined, [landWorks.address, mockERC721Registry.address]);
 
             await landWorks.setMetaverseName(metaverseID, metaverseName);
@@ -3839,7 +3865,7 @@ describe('LandWorks', function () {
             await landWorks.setFee(ADDRESS_ONE, FEE_PERCENTAGE);
 
             // and:
-            await mockERC721Registry.approve(landWorks.address, tokenID);
+            await mockERC721Registry.setApprovalForAll(landWorks.address, true);
 
             await landWorks
                 .list(
@@ -4025,6 +4051,369 @@ describe('LandWorks', function () {
         describe('', async () => {
             beforeEach(async () => {
                 await landWorks.setConsumableAdapter(mockERC721Registry.address, metaverseAdapter.address);
+            });
+
+            describe('listAndSetAdminConsumer', async () => {
+                const assetId = 1;
+                let mockERC20Registry: any;
+
+                beforeEach(async () => {
+                    // given:
+                    mockERC20Registry = await Deployer.deployContract('ERC20Mock');
+                    await landWorks.setAdministrativeConsumerFor(mockERC721Registry.address, administrativeConsumer.address);
+                });
+
+                it('should list successfully', async () => {
+                    // when:
+                    await landWorks.listAndSetAdminConsumer(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+
+                    // then:
+                    expect(await mockERC721Registry.ownerOf(secondMetaverseTokenID)).to.equal(landWorks.address);
+                    expect(await landWorks.ownerOf(assetId)).to.equal(owner.address);
+                    // and:
+                    const asset = await landWorks.assetAt(assetId);
+                    expect(asset.metaverseId).to.equal(metaverseID);
+                    expect(asset.metaverseRegistry).to.equal(mockERC721Registry.address);
+                    expect(asset.metaverseAssetId).to.equal(secondMetaverseTokenID);
+                    expect(asset.paymentToken).to.equal(ADDRESS_ONE);
+                    expect(asset.minPeriod).to.equal(minPeriod);
+                    expect(asset.maxPeriod).to.equal(maxPeriod);
+                    expect(asset.maxFutureTime).to.equal(maxFutureTime);
+                    expect(asset.pricePerSecond).equal(pricePerSecond);
+                    expect(asset.status).to.equal(0); // Listed
+                    expect(asset.totalRents).to.equal(0);
+                    expect(await landWorks.totalSupply()).to.equal(2);
+                    expect(await landWorks.tokenOfOwnerByIndex(owner.address, assetId)).to.equal(assetId);
+                    expect(await landWorks.tokenByIndex(assetId)).to.equal(assetId);
+                    // and:
+                    expect(await metaverseAdapter.consumerOf(secondMetaverseTokenID)).to.equal(administrativeConsumer.address);
+                });
+
+                it('should emit event with args', async () => {
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.emit(landWorks, 'ConsumerChanged')
+                        .withArgs(ethers.constants.AddressZero, ethers.constants.AddressZero, assetId)
+                        .to.emit(landWorks, 'Transfer')
+                        .withArgs(ethers.constants.AddressZero, owner.address, assetId)
+                        .to.emit(landWorks, 'List')
+                        .withArgs(assetId, metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond)
+                        .to.emit(landWorks, 'UpdateAdministrativeState')
+                        .withArgs(assetId, administrativeOperator.address)
+                        .to.emit(metaverseAdapter, 'ConsumerChanged')
+                        .withArgs(landWorks.address, administrativeConsumer.address, secondMetaverseTokenID);
+                });
+
+                it('should list successfully with a payment token', async () => {
+                    // and:
+                    await landWorks.setTokenPayment(mockERC20Registry.address, 0, true);
+
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            mockERC20Registry.address,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.emit(landWorks, 'ConsumerChanged')
+                        .withArgs(ethers.constants.AddressZero, ethers.constants.AddressZero, assetId)
+                        .to.emit(landWorks, 'Transfer')
+                        .withArgs(ethers.constants.AddressZero, owner.address, assetId)
+                        .to.emit(landWorks, 'List')
+                        .withArgs(1, metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, mockERC20Registry.address, pricePerSecond);
+
+                    // then:
+                    expect(await mockERC721Registry.ownerOf(secondMetaverseTokenID)).to.equal(landWorks.address);
+                    expect(await landWorks.ownerOf(assetId)).to.equal(owner.address);
+                    // and:
+                    const asset = await landWorks.assetAt(assetId);
+                    expect(asset.metaverseId).to.equal(metaverseID);
+                    expect(asset.metaverseRegistry).to.equal(mockERC721Registry.address);
+                    expect(asset.metaverseAssetId).to.equal(secondMetaverseTokenID);
+                    expect(asset.paymentToken).to.equal(mockERC20Registry.address);
+                    expect(asset.minPeriod).to.equal(minPeriod);
+                    expect(asset.maxPeriod).to.equal(maxPeriod);
+                    expect(asset.maxFutureTime).to.equal(maxFutureTime);
+                    expect(asset.pricePerSecond).equal(pricePerSecond);
+                    expect(asset.status).to.equal(0); // Listed
+                    expect(asset.totalRents).to.equal(0);
+                    // and:
+                    expect(await metaverseAdapter.consumerOf(secondMetaverseTokenID)).to.equal(administrativeConsumer.address);
+                });
+
+                it('should revert when metaverse registry is 0x0', async () => {
+                    const expectedRevertMessage = '_metaverseRegistry must not be 0x0';
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            ethers.constants.AddressZero,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            mockERC20Registry.address,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when min period is 0', async () => {
+                    const expectedRevertMessage = '_minPeriod must not be 0';
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            0,
+                            maxPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when max period is 0', async () => {
+                    const expectedRevertMessage = '_maxPeriod must not be 0';
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            0,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when min period exceeds max period', async () => {
+                    const expectedRevertMessage = '_minPeriod more than _maxPeriod';
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            maxPeriod,
+                            minPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when max period exceeds max future time', async () => {
+                    const expectedRevertMessage = '_maxPeriod more than _maxFutureTime';
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxFutureTime,
+                            maxPeriod,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when registry is not supported', async () => {
+                    const expectedRevertMessage = '_registry not supported';
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            artificialRegistry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when payment token is not supported', async () => {
+                    const expectedRevertMessage = 'payment type not supported';
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            mockERC20Registry.address,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when trying to list a non-existing metaverse token id', async () => {
+                    const invalidTokenId = 1234;
+                    const expectedRevertMessage = 'ERC721: operator query for nonexistent token';
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            invalidTokenId,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when trying to list to a non-contract metaverse registry', async () => {
+                    // given:
+                    await landWorks.setRegistry(metaverseID, artificialRegistry.address, true);
+
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            artificialRegistry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.reverted;
+                });
+
+                it('should revert when caller is not approved for the to-be-listed asset', async () => {
+                    // given:
+                    const expectedRevertMessage = 'ERC721: transfer caller is not owner nor approved';
+
+                    await mockERC721Registry.setApprovalForAll(landWorks.address, false);
+
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when caller is not owner of the to-be-listed asset', async () => {
+                    const expectedRevertMessage = 'ERC721: transfer of token that is not own';
+
+                    // when:
+                    await expect(landWorks
+                        .connect(administrativeConsumer)
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            ethers.constants.AddressZero
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('should revert when referrer is not whitelisted', async () => {
+                    const expectedRevertMessage = '_referrer not whitelisted';
+
+                    // when:
+                    await expect(landWorks
+                        .listAndSetAdminConsumer(
+                            metaverseID,
+                            mockERC721Registry.address,
+                            secondMetaverseTokenID,
+                            minPeriod,
+                            maxPeriod,
+                            maxFutureTime,
+                            ADDRESS_ONE,
+                            pricePerSecond,
+                            nonOwner.address
+                        ))
+                        .to.be.revertedWith(expectedRevertMessage);
+                });
+
+                it('withdrawing and listing again should not get the old token id for the latest asset', async () => {
+                    const newlyGeneratedTokenId = 2;
+                    // given:
+                    await landWorks.listAndSetAdminConsumer(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+                    await landWorks.delist(assetId);
+
+                    // when:
+                    await landWorks.listAndSetAdminConsumer(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+
+                    // then:
+                    await expect(landWorks.ownerOf(assetId)).to.be.revertedWith('ERC721: owner query for nonexistent token');
+                    // and:
+                    expect(await mockERC721Registry.ownerOf(secondMetaverseTokenID)).to.equal(landWorks.address);
+                    expect(await landWorks.ownerOf(newlyGeneratedTokenId)).to.be.equal(owner.address);
+                    // and:
+                    const asset = await landWorks.assetAt(newlyGeneratedTokenId);
+                    expect(asset.metaverseId).to.equal(metaverseID);
+                    expect(asset.metaverseRegistry).to.equal(mockERC721Registry.address);
+                    expect(asset.metaverseAssetId).to.equal(secondMetaverseTokenID);
+                    expect(asset.paymentToken).to.equal(ADDRESS_ONE);
+                    expect(asset.minPeriod).to.equal(minPeriod);
+                    expect(asset.maxPeriod).to.equal(maxPeriod);
+                    expect(asset.maxFutureTime).to.equal(maxFutureTime);
+                    expect(asset.pricePerSecond).equal(pricePerSecond);
+                    expect(asset.status).to.equal(0); // Listed
+                    expect(asset.totalRents).to.equal(0);
+                    expect(await landWorks.totalSupply()).to.equal(2);
+                    expect(await landWorks.tokenOfOwnerByIndex(owner.address, 1)).to.equal(newlyGeneratedTokenId);
+                    expect(await landWorks.tokenByIndex(1)).to.equal(newlyGeneratedTokenId);
+                });
             });
 
             describe('rentWithConsumer', async () => {

--- a/test/diamond.test.ts
+++ b/test/diamond.test.ts
@@ -4065,7 +4065,7 @@ describe('LandWorks', function () {
 
                 it('should list successfully', async () => {
                     // when:
-                    await landWorks.listAndSetAdminConsumer(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+                    await landWorks.listWithConsumableAdapter(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
 
                     // then:
                     expect(await mockERC721Registry.ownerOf(secondMetaverseTokenID)).to.equal(landWorks.address);
@@ -4092,7 +4092,7 @@ describe('LandWorks', function () {
                 it('should emit event with args', async () => {
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4121,7 +4121,7 @@ describe('LandWorks', function () {
 
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4162,7 +4162,7 @@ describe('LandWorks', function () {
                     const expectedRevertMessage = '_metaverseRegistry must not be 0x0';
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             ethers.constants.AddressZero,
                             secondMetaverseTokenID,
@@ -4180,7 +4180,7 @@ describe('LandWorks', function () {
                     const expectedRevertMessage = '_minPeriod must not be 0';
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4198,7 +4198,7 @@ describe('LandWorks', function () {
                     const expectedRevertMessage = '_maxPeriod must not be 0';
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4216,7 +4216,7 @@ describe('LandWorks', function () {
                     const expectedRevertMessage = '_minPeriod more than _maxPeriod';
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4234,7 +4234,7 @@ describe('LandWorks', function () {
                     const expectedRevertMessage = '_maxPeriod more than _maxFutureTime';
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4252,7 +4252,7 @@ describe('LandWorks', function () {
                     const expectedRevertMessage = '_registry not supported';
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             artificialRegistry.address,
                             secondMetaverseTokenID,
@@ -4270,7 +4270,7 @@ describe('LandWorks', function () {
                     const expectedRevertMessage = 'payment type not supported';
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4289,7 +4289,7 @@ describe('LandWorks', function () {
                     const expectedRevertMessage = 'ERC721: operator query for nonexistent token';
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             invalidTokenId,
@@ -4309,7 +4309,7 @@ describe('LandWorks', function () {
 
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             artificialRegistry.address,
                             secondMetaverseTokenID,
@@ -4331,7 +4331,7 @@ describe('LandWorks', function () {
 
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4351,7 +4351,7 @@ describe('LandWorks', function () {
                     // when:
                     await expect(landWorks
                         .connect(administrativeConsumer)
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4370,7 +4370,7 @@ describe('LandWorks', function () {
 
                     // when:
                     await expect(landWorks
-                        .listAndSetAdminConsumer(
+                        .listWithConsumableAdapter(
                             metaverseID,
                             mockERC721Registry.address,
                             secondMetaverseTokenID,
@@ -4387,11 +4387,11 @@ describe('LandWorks', function () {
                 it('withdrawing and listing again should not get the old token id for the latest asset', async () => {
                     const newlyGeneratedTokenId = 2;
                     // given:
-                    await landWorks.listAndSetAdminConsumer(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+                    await landWorks.listWithConsumableAdapter(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
                     await landWorks.delist(assetId);
 
                     // when:
-                    await landWorks.listAndSetAdminConsumer(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
+                    await landWorks.listWithConsumableAdapter(metaverseID, mockERC721Registry.address, secondMetaverseTokenID, minPeriod, maxPeriod, maxFutureTime, ADDRESS_ONE, pricePerSecond, ethers.constants.AddressZero);
 
                     // then:
                     await expect(landWorks.ownerOf(assetId)).to.be.revertedWith('ERC721: owner query for nonexistent token');


### PR DESCRIPTION
**Detailed description**:
* Set administrative operator upon listing using `listDecentraland` and `listWithConsumableAdapter `

**Which issue(s) this PR fixes**:
Fixes #none
**Special notes for your reviewer**:

**Checklist**
- [x] Documentation added
- [x] Tests updated